### PR TITLE
Fix variable reference in log statement

### DIFF
--- a/vonx/indy/service.py
+++ b/vonx/indy/service.py
@@ -1241,7 +1241,7 @@ class IndyService(ServiceBase):
                                         CredentialDependency(dep.name, dep.version, dep.origin_did)
                                     )
 
-                                    LOGGER.debug("Await get-credential-dependencies for known schema %s", dep.schema_name)
+                                    LOGGER.debug("Await get-credential-dependencies for known schema %s", schema_name)
                                     dependency_dependencies = await self._get_credential_dependencies(
                                         dep.name,
                                         dep.version,


### PR DESCRIPTION
Fixed incorrect variable reference in log statement.
Signed-off-by: Emiliano Suñé <emiliano.sune@gmail.com>

@cywolf 