### PR TITLE
Enable CORS on standard agent routes.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ setup(
     python_requires='>=3.5.3',
     install_requires=[
         'aiohttp~=3.3.0',
+        'aiohttp_cors~=0.7.0',
         'aiohttp-jinja2~=1.1.0',
         'didauth==1.2.3',
         'PyYAML',

--- a/vonx/web/routes.py
+++ b/vonx/web/routes.py
@@ -32,7 +32,7 @@ from .render import render_form
 LOGGER = logging.getLogger(__name__)
 
 
-def get_standard_routes(_app) -> list:
+def get_standard_routes(app: web.Application) -> list:
     """
     Get the standard list of routes for the von-x application
     """


### PR DESCRIPTION
@cywolf 
C.C.: @nrempel 

This enables CORS on the standard routes exposed by the agent. This is required to be able to call `/get-credential-dependencies` from a browser (e.g.: using dFlow).

Custom routes are being created differently, and this causes issues when trying to enable CORS. I therefore split the route creation/initialization into two steps, so that CORS could be enabled on standard routes only. If this is not the right way to handle this it will be necessary to further investigate why enabling CORS fails for custom routes.